### PR TITLE
[feat] submit forms using enter button without having to explicitly mouse clicking on submit button

### DIFF
--- a/src/views/Login.vue
+++ b/src/views/Login.vue
@@ -14,6 +14,7 @@
             name="user_name"
             placeholder="Team Name*"
             v-model="username"
+            @keyup.enter="triggerLogin"
           />
         </div>
         <div class="info">
@@ -24,6 +25,7 @@
             name="user_pass"
             placeholder="Password*"
             v-model="password"
+            @keyup.enter="triggerLogin"
           />
         </div>
         <Button
@@ -58,6 +60,11 @@ export default {
     Button
   },
   methods: {
+    triggerLogin() {
+      if (this.username && this.password) {
+        this.login();
+      }
+    },
     async login() {
       const check = await LoginUser.loggedInUser(this.username, this.password);
       if (check === 400) {

--- a/src/views/Register.vue
+++ b/src/views/Register.vue
@@ -17,6 +17,7 @@
             name="name"
             placeholder="Name*"
             required="true"
+            @keyup.enter="triggerRegister"
           />
         </div>
         <div class="info">
@@ -28,6 +29,7 @@
             name="user_name"
             placeholder="Username*"
             required="true"
+            @keyup.enter="triggerRegister"
           />
         </div>
         <div class="info">
@@ -39,6 +41,7 @@
             name="user_email"
             placeholder="Email*"
             required="true"
+            @keyup.enter="triggerRegister"
           />
           <div class="text-field-error" v-if="EmailErr">
             <img src="@/assets/error.svg" class="errImg" /> {{ this.EmailErr }}
@@ -53,6 +56,7 @@
             name="user_pass"
             placeholder="Password*"
             required="true"
+            @keyup.enter="triggerRegister"
           />
         </div>
         <div class="info">
@@ -64,6 +68,7 @@
             name="user_pass"
             placeholder="Confirm Password*"
             required="true"
+            @keyup.enter="triggerRegister"
           />
           <div class="text-field-error" v-if="PassErr">
             <img src="@/assets/error.svg" class="errImg" /> {{ this.PassErr }}
@@ -116,6 +121,17 @@ export default {
     },
     sleep(ms) {
       return new Promise(resolve => setTimeout(resolve, ms));
+    },
+    triggerRegister() {
+      if (
+        this.uname &&
+        this.username &&
+        this.password &&
+        this.password2 &&
+        this.email
+      ) {
+        this.register();
+      }
     },
     async register() {
       if (!this.validateEmail(this.email)) {

--- a/src/views/Reset.vue
+++ b/src/views/Reset.vue
@@ -16,6 +16,7 @@
             name="user_pass"
             placeholder="New Password*"
             required="true"
+            @keyup.enter="triggerReset"
           />
         </div>
         <div class="info">
@@ -27,6 +28,7 @@
             name="user_pass"
             placeholder="Confirm Password*"
             required="true"
+            @keyup.enter="triggerReset"
           />
           <div class="error-box" v-if="PassErr">
             <img src="@/assets/error.svg" class="errImg" /> {{ this.PassErr }}
@@ -70,6 +72,11 @@ export default {
   methods: {
     sleep(ms) {
       return new Promise(resolve => setTimeout(resolve, ms));
+    },
+    triggerReset() {
+      if (this.password && this.password2) {
+        this.reset();
+      }
     },
     async reset() {
       if (this.password !== this.password2) {


### PR DESCRIPTION
Users can now submit forms using enter button after filling all the necessary fields instead of explicitly clicking on the submit button, as pressing enter to submit a form is more UX friendly.